### PR TITLE
Fix calendar title error - off by one month

### DIFF
--- a/src/frontend/calendar/index.js
+++ b/src/frontend/calendar/index.js
@@ -64,7 +64,7 @@ function Calendar() {
 				</nav>
 				<div>
 					<h2 aria-live="polite" aria-atomic>
-						{ date( 'F Y', new Date( year, month, 1 ) ) }
+						{ date( 'F Y', new Date( year, month, 2 ) ) }
 					</h2>
 				</div>
 				<nav


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR passes timezone offset to function `date`.

<!-- Reference any related issues or PRs here. Each issue needs the "fixes" keyword if the PR fixes more than one thing. -->
Fixes #130

### Root Cause
**1. Gutenberg PR**

In this [Gutenberg PR](https://github.com/WordPress/gutenberg/commit/266799ed7fca002f7dd7b706d07ca481fcee665c), this [line](https://github.com/WordPress/gutenberg/blob/266799ed7fca002f7dd7b706d07ca481fcee665c/packages/date/src/index.js#L592) is changed by prefixing a plus sign. This change fixes the issue that there are some cases where the inputs are illegal for `utcOffset`. 

https://momentjscom.readthedocs.io/en/latest/moment/03-manipulating/09-utc-offset/#
> moment#utcOffset will search the string for the last match of +00 -00 +00:00 +0000
-00:00 -0000 Z, so you can even pass an ISO8601 formatted string with offset and the moment will be changed to that UTC offset.
> 
> Note that if the string does not include 'Z', it must include the + or - character.

And take the following cases as an example, the date function returns inconsistent month numbers due to the input type difference. And this would lead to the wrong date time for some users.

Before fixing: https://d.pr/v/vwf10t
After fixing: https://d.pr/v/MUK5u1

We can see that, after fixing, it always shows April no matter whether we select UTC+1 (string) or London (integer).

**2. Local time (Date Object) and Website timezone offset**

How does Gutenberg fix affect the Make WordPress Meeting Calendar and the Learn Social Learning Calendar?
Since the WP site timezone is set to UTC+0, which is a string sent to the function `utcOffset`, it's an illegal string.

![image](https://user-images.githubusercontent.com/18050944/170624203-26993774-f385-4fff-be9b-bf85019ef5a1.png)

And we can see from the above testing cases that, if it's an illegal string, it will show `May`. You may wonder, isn't that what we want? Yes and no, we're kind of just lucky here. The '0' is supposed to add the info of timezone offset to the `moment(new Date(...))` object, but it fails. This means we have never set the offset correctly before, so the timezone offset of the `moment(new Date(...))` object would remain at the user's local timezone instead of being adjusted to the website timezone. However, this is actually what we want, since our `moment(new Date(...))` is in the local timezone, we don't want it to change to the website timezone - after the Gutenberg fix, it always passes an integer to `utcOffset`, which converts our `moment(new Date(...))` to website timezone, so you can see the first test case in the above image, my Date object timezone is +8 and it's changed to website offset by `utcOffset`, converting the Date object to the time 8 hours earlier, which is April 30.

Therefore, we don't want to use the default offset of the `date` function - which is the website timezone offset. So one way to fix it is to pass down the local timezone offset to the function. If doing this way, there's one more thing, we need to prefix a minus sign to the offset. Why? 

1. moment.js uses real offset as input. See https://momentjscom.readthedocs.io/en/latest/moment/03-manipulating/09-utc-offset/#
2. Date object uses reverse offset. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset#negative_values_and_positive_values.

Since it's kind of tricky and takes time to understand the solution brought up above, in this PR, we just implement the workaround mentioned [here](https://github.com/WordPress/meeting-calendar/issues/130#issuecomment-1135717404).

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots of Result (Tested on Sandbox and local env)
![Screen Shot 2022-05-27 at 9 50 15 AM](https://user-images.githubusercontent.com/18050944/170626469-90ab1a37-78fe-45ce-9d5c-67118d3c5057.png)
![Screen Shot 2022-05-27 at 9 49 40 AM](https://user-images.githubusercontent.com/18050944/170626457-551d2666-8687-4070-8062-1b01cda4911f.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. `wp-env` an env with the latest Gutenberg version (13.4.0) and meeting-calendar.
2. Create a post with a calendar and check the month in the title.
Note: If your local timezone is not >= +1, you won't see any difference after this fix. Your month wasn't affected in the beginning.

<!-- If you can, add the appropriate [Component] label(s). -->
