### PR TITLE
Add WPTV URL meta field

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -21,15 +21,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - name: Install dependencies
-        run: composer install --dev --prefer-dist --no-progress --no-suggest
-
-      - name: Run phpcs
-        uses: chekalsky/phpcs-action@v1
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          phpcs_bin_path: './vendor/bin/phpcs'
+          php-version: '7.4'
+          coverage: none
+          tools: composer, cs2pr
+
+      - name: Install Composer dependencies
+        run: |
+          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
+
+      - name: Run PHPCS
+        run: |
+          vendor/bin/phpcs -q --report=checkstyle src | cs2pr
 
   unit-php:
     name: PHP Unit Tests

--- a/includes/ical-generator-functions.php
+++ b/includes/ical-generator-functions.php
@@ -45,6 +45,7 @@ function generate_event( $post ) {
 	$title     = $post->post_title;
 	$location  = $post->location;
 	$link      = $post->link;
+	$wptv_url  = $post->wptv_url;
 	$team      = $post->team;
 	$recurring = $post->recurring;
 	$sequence  = empty( $post->sequence ) ? 0 : intval( $post->sequence );
@@ -63,6 +64,10 @@ function generate_event( $post ) {
 	if ( $location && preg_match( '/^#([-\w]+)$/', trim( $location ), $match ) ) {
 		$slack_channel = '#' . sanitize_title( $match[1] );
 		$location      = "{$slack_channel} channel on Slack";
+	}
+
+	if ( $wptv_url ) {
+		$description .= "WPTV URL link: {$wptv_url}\\n";
 	}
 
 	if ( $link ) {

--- a/includes/ical-generator-functions.php
+++ b/includes/ical-generator-functions.php
@@ -67,7 +67,7 @@ function generate_event( $post ) {
 	}
 
 	if ( $wptv_url ) {
-		$description .= "WPTV URL link: {$wptv_url}\\n";
+		$description .= "WordPress.tv link: {$wptv_url}\\n";
 	}
 
 	if ( $link ) {

--- a/includes/wporg-meeting-install.php
+++ b/includes/wporg-meeting-install.php
@@ -23,6 +23,7 @@ function wporg_meeting_install() {
 					'recurring'  => 'weekly',
 					'link'       => 'wordpress.org',
 					'location'   => '#meta',
+					'wptv_url'   => 'https://wordpress.org',
 				),
 			)
 		);
@@ -40,6 +41,7 @@ function wporg_meeting_install() {
 					'recurring'  => 'monthly',
 					'link'       => 'wordpress.org',
 					'location'   => '#meta',
+					'wptv_url'   => 'https://wordpress.org',
 				),
 			)
 		);
@@ -58,6 +60,7 @@ function wporg_meeting_install() {
 					'occurrence' => array( 3 ),
 					'link'       => 'wordpress.org',
 					'location'   => '#meta',
+					'wptv_url'   => 'https://wordpress.org',
 				),
 			)
 		);

--- a/includes/wporg-meeting-install.php
+++ b/includes/wporg-meeting-install.php
@@ -23,7 +23,7 @@ function wporg_meeting_install() {
 					'recurring'  => 'weekly',
 					'link'       => 'wordpress.org',
 					'location'   => '#meta',
-					'wptv_url'   => 'https://wordpress.org',
+					'wptv_url'   => 'https://wordpress.tv',
 				),
 			)
 		);
@@ -41,7 +41,7 @@ function wporg_meeting_install() {
 					'recurring'  => 'monthly',
 					'link'       => 'wordpress.org',
 					'location'   => '#meta',
-					'wptv_url'   => 'https://wordpress.org',
+					'wptv_url'   => 'https://wordpress.tv',
 				),
 			)
 		);
@@ -60,7 +60,7 @@ function wporg_meeting_install() {
 					'occurrence' => array( 3 ),
 					'link'       => 'wordpress.org',
 					'location'   => '#meta',
-					'wptv_url'   => 'https://wordpress.org',
+					'wptv_url'   => 'https://wordpress.tv',
 				),
 			)
 		);

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -582,7 +582,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 		</p>
 		<p>
 		<p>
-		<label for="wptv_url"><?php esc_html_e( 'WPTV URL: ', 'wporg-meeting-calendar' ); ?></label>
+		<label for="wptv_url"><?php esc_html_e( 'WordPress.tv URL: ', 'wporg-meeting-calendar' ); ?></label>
 			<input
 				type="url"
 				name="wptv_url"

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -54,7 +54,9 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 		public function meeting_add_custom_columns( $columns ) {
 			$columns = array_slice( $columns, 0, 1, true )
 				+ array( 'team' => __( 'Team', 'wporg-meeting-calendar' ) )
-				+ array_slice( $columns, 1, null, true );
+				+ array_slice( $columns, 1, -1, true )
+				+ array( 'wptv_url' => __( 'WPTV URL', 'wporg-meeting-calendar' ) )
+				+ array_slice( $columns, -1, null, true );
 			return $columns;
 		}
 
@@ -63,6 +65,12 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 				case 'team':
 					$team = get_post_meta( $post_id, 'team', true );
 					echo esc_html( $team );
+					break;
+			}
+			switch ( $column ) {
+				case 'wptv_url':
+					$wptv_url = get_post_meta( $post_id, 'wptv_url', true );
+					echo esc_html( $wptv_url ?: '—' );
 					break;
 			}
 		}
@@ -292,6 +300,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 				'recurring',
 				'link',
 				'location',
+				'wptv_url',
 			);
 			foreach ( $meta_keys as $key ) {
 				register_meta(
@@ -370,6 +379,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 						'link'        => $meeting->link,
 						'title'       => wp_specialchars_decode( $meeting->post_title, ENT_QUOTES ),
 						'location'    => $meeting->location,
+						'wptv_url'    => $meeting->wptv_url,
 						'recurring'   => $meeting->recurring,
 						'occurrence'  => $meeting->occurrence,
 						'status'      => ( $this->is_meeting_cancelled( $meeting->ID, $occurrence ) ? 'cancelled' : 'active' ),
@@ -496,6 +506,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			$occurrence = isset( $meta['occurrence'][0] ) ? unserialize( $meta['occurrence'][0] ) : array();
 			$link       = isset( $meta['link'][0] ) ? $meta['link'][0] : '';
 			$location   = isset( $meta['location'][0] ) ? $meta['location'][0] : '';
+			$wptv_url   = isset( $meta['wptv_url'][0] ) ? $meta['wptv_url'][0] : '';
 			wp_nonce_field( 'save_meeting_meta_' . $post->ID, 'meeting_nonce' );
 			?>
 
@@ -569,6 +580,18 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			<input type="text" name="location" id="location" class="regular-text wide" value="<?php echo esc_attr( $location ); ?>">
 		</label>
 		</p>
+		<p>
+		<p>
+		<label for="wptv_url"><?php esc_html_e( 'WPTV URL: ', 'wporg-meeting-calendar' ); ?></label>
+			<input
+				type="url"
+				name="wptv_url"
+				id="wptv_url"
+				class="regular-text wide"
+				value="<?php echo esc_url( $wptv_url ); ?>"
+			/>
+		</p>
+
 		<script>
 		jQuery(document).ready( function($) {
 			$('.date').datepicker({
@@ -715,6 +738,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 								 ? array_map( 'intval', $_POST['occurrence'] ) : array() );
 			$meta['link']       = ( isset( $_POST['link'] ) ? esc_url( $_POST['link'] ) : '' );
 			$meta['location']   = ( isset( $_POST['location'] ) ? esc_textarea( $_POST['location'] ) : '' );
+			$meta['wptv_url']   = ( isset( $_POST['wptv_url'] ) ? esc_url( $_POST['wptv_url'] ) : '' );
 
 			foreach ( $meta as $key => $value ) {
 				update_post_meta( $post->ID, $key, $value );

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -581,7 +581,6 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 		</label>
 		</p>
 		<p>
-		<p>
 		<label for="wptv_url"><?php esc_html_e( 'WordPress.tv URL: ', 'wporg-meeting-calendar' ); ?></label>
 			<input
 				type="url"

--- a/src/frontend/calendar/modal.js
+++ b/src/frontend/calendar/modal.js
@@ -73,6 +73,13 @@ function EventModal( { event, onRequestClose } ) {
 					{ __( 'Add to Google Calendar', 'wporg-meeting-calendar' ) }
 				</a>
 			</p>
+			{ !! event.wptv_url && (
+				<p>
+					<a href={ event.wptv_url }>
+						{ __( 'View Recording', 'wporg-meeting-calendar' ) }
+					</a>
+				</p>
+			) }
 		</Modal>
 	);
 }

--- a/src/frontend/calendar/modal.js
+++ b/src/frontend/calendar/modal.js
@@ -75,7 +75,7 @@ function EventModal( { event, onRequestClose } ) {
 			</p>
 			{ !! event.wptv_url && (
 				<p>
-					<a href={ event.wptv_url }>
+					<a aria-label={ __( 'WPTV URL of the meeting recording', 'wporg-meeting-calendar' ) } href={ event.wptv_url }>
 						{ __( 'View Recording', 'wporg-meeting-calendar' ) }
 					</a>
 				</p>

--- a/src/frontend/calendar/modal.js
+++ b/src/frontend/calendar/modal.js
@@ -75,7 +75,7 @@ function EventModal( { event, onRequestClose } ) {
 			</p>
 			{ !! event.wptv_url && (
 				<p>
-					<a aria-label={ __( 'WPTV URL of the meeting recording', 'wporg-meeting-calendar' ) } href={ event.wptv_url }>
+					<a aria-label={ __( 'WordPress.tv URL for the meeting recording', 'wporg-meeting-calendar' ) } href={ event.wptv_url }>
 						{ __( 'View Recording', 'wporg-meeting-calendar' ) }
 					</a>
 				</p>

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -90,7 +90,7 @@ function ListItem( { date, events } ) {
 									{ getSlackLink( event.location ) }
 								</p>
 								<p className="wporg-meeting-calendar__list-event-copy">
-									<a href={ event.wptv_url }>{ __( 'View Recording', 'wporg-meeting-calendar' ) }</a>
+									<a aria-label={ __( 'WPTV URL of the meeting recording', 'wporg-meeting-calendar' ) } href={ event.wptv_url }>{ __( 'View Recording', 'wporg-meeting-calendar' ) }</a>
 								</p>
 							</div>
 						</div>

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -90,7 +90,7 @@ function ListItem( { date, events } ) {
 									{ getSlackLink( event.location ) }
 								</p>
 								<p className="wporg-meeting-calendar__list-event-copy">
-									<a aria-label={ __( 'WPTV URL of the meeting recording', 'wporg-meeting-calendar' ) } href={ event.wptv_url }>{ __( 'View Recording', 'wporg-meeting-calendar' ) }</a>
+									<a aria-label={ __( 'WordPress.tv URL for the meeting recording', 'wporg-meeting-calendar' ) } href={ event.wptv_url }>{ __( 'View Recording', 'wporg-meeting-calendar' ) }</a>
 								</p>
 							</div>
 						</div>

--- a/src/frontend/list/list-item.js
+++ b/src/frontend/list/list-item.js
@@ -89,6 +89,9 @@ function ListItem( { date, events } ) {
 									{ __( 'Location: ', 'wporg-meeting-calendar' ) }
 									{ getSlackLink( event.location ) }
 								</p>
+								<p className="wporg-meeting-calendar__list-event-copy">
+									<a href={ event.wptv_url }>{ __( 'View Recording', 'wporg-meeting-calendar' ) }</a>
+								</p>
 							</div>
 						</div>
 					</article>

--- a/tests/fixtures/events-with-cancel.ics
+++ b/tests/fixtures/events-with-cancel.ics
@@ -17,7 +17,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=WEEKLY
 EXDATE:%EXDATE%
 END:VEVENT

--- a/tests/fixtures/events-with-cancel.ics
+++ b/tests/fixtures/events-with-cancel.ics
@@ -17,7 +17,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WordPress.tv link: https://wordpress.tv\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=WEEKLY
 EXDATE:%EXDATE%
 END:VEVENT

--- a/tests/fixtures/events.ics
+++ b/tests/fixtures/events.ics
@@ -17,7 +17,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=WEEKLY
 END:VEVENT
 BEGIN:VEVENT
@@ -32,7 +32,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=MONTHLY
 END:VEVENT
 BEGIN:VEVENT
@@ -47,7 +47,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:Slack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=MONTHLY;BYDAY=3WE
 END:VEVENT
 END:VCALENDAR

--- a/tests/fixtures/events.ics
+++ b/tests/fixtures/events.ics
@@ -17,7 +17,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WordPress.tv link: https://wordpress.tv\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=WEEKLY
 END:VEVENT
 BEGIN:VEVENT
@@ -32,7 +32,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WordPress.tv link: https://wordpress.tv\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=MONTHLY
 END:VEVENT
 BEGIN:VEVENT
@@ -47,7 +47,7 @@ SEQUENCE:0
 STATUS:CONFIRMED
 TRANSP:OPAQUE
 LOCATION:#meta channel on Slack
-DESCRIPTION:WPTV URL link: https://wordpress.org\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
+DESCRIPTION:WordPress.tv link: https://wordpress.tv\nSlack channel link: https://wordpress.slack.com/messages/#meta\nFor more information visit wordpress.org
 RRULE:FREQ=MONTHLY;BYDAY=3WE
 END:VEVENT
 END:VCALENDAR

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -70,7 +70,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( '14:00:00', $meeting['meta']['time'] );
 		$this->assertEquals( 'weekly', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
-		$this->assertEquals( 'https://wordpress.org', $meeting['meta']['wptv_url'] );
+		$this->assertEquals( 'https://wordpress.tv', $meeting['meta']['wptv_url'] );
 		$this->assertEquals( array(), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
@@ -117,7 +117,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( '15:00:00', $meeting['meta']['time'] );
 		$this->assertEquals( 'monthly', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
-		$this->assertEquals( 'https://wordpress.org', $meeting['meta']['wptv_url'] );
+		$this->assertEquals( 'https://wordpress.tv', $meeting['meta']['wptv_url'] );
 		$this->assertEquals( array(), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
@@ -161,7 +161,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( '16:00:00', $meeting['meta']['time'] );
 		$this->assertEquals( 'occurrence', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
-		$this->assertEquals( 'https://wordpress.org', $meeting['meta']['wptv_url'] );
+		$this->assertEquals( 'https://wordpress.tv', $meeting['meta']['wptv_url'] );
 		$this->assertEquals( array( 3 ), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
@@ -204,7 +204,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-01T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -221,7 +221,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-01T15:00:00+00:00',
 				'team'        => 'Team-B',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A monthly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'monthly',
@@ -238,7 +238,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-08T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -255,7 +255,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-15T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -272,7 +272,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-15T16:00:00+00:00',
 				'team'        => 'Team-C',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'Third Wednesday of each month',
 				'location'    => '#meta',
 				'recurring'   => 'occurrence',
@@ -292,7 +292,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-22T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -309,7 +309,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-29T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -326,7 +326,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-01T15:00:00+00:00',
 				'team'        => 'Team-B',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A monthly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'monthly',
@@ -343,7 +343,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-05T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -360,7 +360,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-12T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -377,7 +377,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-19T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -394,7 +394,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-19T16:00:00+00:00',
 				'team'        => 'Team-C',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'Third Wednesday of each month',
 				'location'    => '#meta',
 				'recurring'   => 'occurrence',
@@ -414,7 +414,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-26T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
-				'wptv_url'    => 'https://wordpress.org',
+				'wptv_url'    => 'https://wordpress.tv',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -70,6 +70,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( '14:00:00', $meeting['meta']['time'] );
 		$this->assertEquals( 'weekly', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
+		$this->assertEquals( 'https://wordpress.org', $meeting['meta']['wptv_url'] );
 		$this->assertEquals( array(), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
@@ -116,6 +117,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( '15:00:00', $meeting['meta']['time'] );
 		$this->assertEquals( 'monthly', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
+		$this->assertEquals( 'https://wordpress.org', $meeting['meta']['wptv_url'] );
 		$this->assertEquals( array(), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
@@ -159,6 +161,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 		$this->assertEquals( '16:00:00', $meeting['meta']['time'] );
 		$this->assertEquals( 'occurrence', $meeting['meta']['recurring'] );
 		$this->assertEquals( 'wordpress.org', $meeting['meta']['link'] );
+		$this->assertEquals( 'https://wordpress.org', $meeting['meta']['wptv_url'] );
 		$this->assertEquals( array( 3 ), $meeting['meta']['occurrence'] );
 
 		$this->assertTrue( is_array( $meeting['future_occurrences'] ) );
@@ -201,6 +204,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-01T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -217,6 +221,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-01T15:00:00+00:00',
 				'team'        => 'Team-B',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A monthly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'monthly',
@@ -233,6 +238,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-08T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -249,6 +255,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-15T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -265,6 +272,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-15T16:00:00+00:00',
 				'team'        => 'Team-C',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'Third Wednesday of each month',
 				'location'    => '#meta',
 				'recurring'   => 'occurrence',
@@ -284,6 +292,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-22T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -300,6 +309,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-01-29T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -316,6 +326,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-01T15:00:00+00:00',
 				'team'        => 'Team-B',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A monthly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'monthly',
@@ -332,6 +343,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-05T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -348,6 +360,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-12T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -364,6 +377,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-19T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',
@@ -380,6 +394,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-19T16:00:00+00:00',
 				'team'        => 'Team-C',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'Third Wednesday of each month',
 				'location'    => '#meta',
 				'recurring'   => 'occurrence',
@@ -399,6 +414,7 @@ class MeetingAPITest extends WP_UnitTestCase {
 				'datetime'    => '2020-02-26T14:00:00+00:00',
 				'team'        => 'Team-A',
 				'link'        => 'wordpress.org',
+				'wptv_url'    => 'https://wordpress.org',
 				'title'       => 'A weekly meeting',
 				'location'    => '#meta',
 				'recurring'   => 'weekly',

--- a/tests/test-meetingposttype.php
+++ b/tests/test-meetingposttype.php
@@ -38,6 +38,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => '',
 					'link'       => 'wordpress.org',
+					'wptv_url'    => 'https://wordpress.org',
 					'location'   => '#meta',
 				),
 			)
@@ -67,6 +68,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 					'time'       => '0100 UTC', // Some production data is formatted like this
 					'recurring'  => '',
 					'link'       => 'wordpress.org',
+					'wptv_url'    => 'https://wordpress.org',
 					'location'   => '#meta',
 				),
 			)
@@ -98,6 +100,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => '',
 					'link'       => '&wordpress.org',
+					'wptv_url'   => '&https://wordpress.org',
 					'location'   => '&meta',
 				),
 			)
@@ -111,6 +114,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 				++$found;
 				$this->assertEquals( 'Team-A&B', $meeting['team'] );
 				$this->assertEquals( '&wordpress.org', $meeting['link'] );
+				$this->assertEquals( '&https://wordpress.org', $meeting['wptv_url'] );
 				$this->assertEquals( '&meta', $meeting['location'] );
 				$this->assertEquals( 'A & B meeting', $meeting['title'] );
 			}

--- a/tests/test-meetingposttype.php
+++ b/tests/test-meetingposttype.php
@@ -38,7 +38,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => '',
 					'link'       => 'wordpress.org',
-					'wptv_url'    => 'https://wordpress.org',
+					'wptv_url'    => 'https://wordpress.tv',
 					'location'   => '#meta',
 				),
 			)
@@ -68,7 +68,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 					'time'       => '0100 UTC', // Some production data is formatted like this
 					'recurring'  => '',
 					'link'       => 'wordpress.org',
-					'wptv_url'    => 'https://wordpress.org',
+					'wptv_url'    => 'https://wordpress.tv',
 					'location'   => '#meta',
 				),
 			)
@@ -100,7 +100,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => '',
 					'link'       => '&wordpress.org',
-					'wptv_url'   => '&https://wordpress.org',
+					'wptv_url'   => '&https://wordpress.tv',
 					'location'   => '&meta',
 				),
 			)
@@ -114,7 +114,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 				++$found;
 				$this->assertEquals( 'Team-A&B', $meeting['team'] );
 				$this->assertEquals( '&wordpress.org', $meeting['link'] );
-				$this->assertEquals( '&https://wordpress.org', $meeting['wptv_url'] );
+				$this->assertEquals( '&https://wordpress.tv', $meeting['wptv_url'] );
 				$this->assertEquals( '&meta', $meeting['location'] );
 				$this->assertEquals( 'A & B meeting', $meeting['title'] );
 			}

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -38,7 +38,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => '',
 					'link'       => 'wordpress.org',
-					'wptv_url'   => 'https://wordpress.org',
+					'wptv_url'   => 'https://wordpress.tv',
 					'location'   => '#meta',
 				),
 			)
@@ -57,7 +57,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 					'time'       => '02:00',
 					'recurring'  => 'weekly',
 					'link'       => 'wordpress.org',
-					'wptv_url'   => 'https://wordpress.org',
+					'wptv_url'   => 'https://wordpress.tv',
 					'location'   => '#meta',
 				),
 			)
@@ -89,7 +89,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => 'weekly',
 					'link'       => 'wordpress.org',
-					'wptv_url'   => 'https://wordpress.org',
+					'wptv_url'   => 'https://wordpress.tv',
 					'location'   => '#meta',
 				),
 			)

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -38,6 +38,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => '',
 					'link'       => 'wordpress.org',
+					'wptv_url'   => 'https://wordpress.org',
 					'location'   => '#meta',
 				),
 			)
@@ -56,6 +57,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 					'time'       => '02:00',
 					'recurring'  => 'weekly',
 					'link'       => 'wordpress.org',
+					'wptv_url'   => 'https://wordpress.org',
 					'location'   => '#meta',
 				),
 			)
@@ -87,6 +89,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 					'time'       => '01:00',
 					'recurring'  => 'weekly',
 					'link'       => 'wordpress.org',
+					'wptv_url'   => 'https://wordpress.org',
 					'location'   => '#meta',
 				),
 			)


### PR DESCRIPTION
Fixes [#1003 ](https://github.com/WordPress/Learn/issues/1003)

This PR
* Add a new meta field, the WPTV URL, with a text field form with URL validation.
* Add `View recording` link to the modal. The URL would be to the wordpress.tv item entered in the meta field.

## Screenshots
#### Edit Screen

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/18050944/227027675-fbee65fe-1e71-4428-aec9-0e1280192073.png">

#### Meeting List

![Screen Shot 2023-03-23 at 4 16 16 AM](https://user-images.githubusercontent.com/18050944/227027696-f13d0645-d2db-4738-b0d0-04329e4c57ec.png)

#### Modal

![Screen Shot 2023-03-23 at 3 59 20 AM](https://user-images.githubusercontent.com/18050944/227027479-1ff37047-b069-4cf8-b10a-a6a0d0d5abf5.png)

#### List 
List items would not show in Learn, but might show in other places. e.g., https://make.wordpress.org/meetings/

![Screen Shot 2023-03-23 at 3 59 09 AM](https://user-images.githubusercontent.com/18050944/227027833-d019f8fb-8b52-4801-8607-f17945bf4f7d.png)

#### ICS Import

![ics](https://user-images.githubusercontent.com/18050944/227027883-58ec4c46-852e-4425-b1a9-e87dcd2613a3.png)

#### Testing instructions
1. Add the plugin `meeting-calendar` and activate it.
2. Go to `/wp-admin/edit.php?post_type=meeting`. There should be three default meetings.
3. On the meeting list and edit screen, there should be a new field `WPTV URL`.
4. If you're adding the plugin to Learn, then go to `/online-workshops/`. Otherwise, create a post and add a meeting block.
5. Click on any of the meetings, then the modal would show up. `View Recording` should be there.
6. Click `List`, in devTools -> Element, search `wporg-meeting-calendar__list-event-copy`, and unclick the `display: none` (in Learn, it was set invisible), `View Recording` should be there.
7. Click `iCal`, and import to your calendar, should see all three meetings are added and show the corresponding info.

## TODO
~Fix PHPCS errors - WP PHPCS is updated to PHP8.0+. Some function usage standards have changed.~

**Update**
~PR to fix the issue is opened: https://github.com/WordPress/meeting-calendar/pull/144~

**Update**

Closed #144 (See reason there) and fixed in [Fix PHPCS error](https://github.com/WordPress/meeting-calendar/pull/143/commits/56d4948f312b5796c65033f630e543f0adf09232).