### PR TITLE
Fix PHPCS Errors

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -14,6 +14,12 @@
 			- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
 
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
 	<!-- Exclude 3rd-party files -->
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>

--- a/includes/ical-generator-functions.php
+++ b/includes/ical-generator-functions.php
@@ -50,12 +50,12 @@ function generate_event( $post ) {
 	$recurring = $post->recurring;
 	$sequence  = empty( $post->sequence ) ? 0 : intval( $post->sequence );
 
-	$start_date      = strftime( '%Y%m%d', strtotime( $post->start_date ) );
-	$start_time      = strftime( '%H%M%S', strtotime( $post->time ) );
+	$start_date      = gmdate( 'Ymd', strtotime( $post->start_date ) );
+	$start_time      = gmdate( 'His', strtotime( $post->time ) );
 	$start_date_time = "{$start_date}T{$start_time}Z";
 
 	$end_date      = $start_date;
-	$end_time      = strftime( '%H%M%S', strtotime( "{$post->time} +1 hour" ) );
+	$end_time      = gmdate( 'His', strtotime( "{$post->time} +1 hour" ) );
 	$end_date_time = "{$end_date}T{$end_time}Z";
 
 	$description   = '';
@@ -112,7 +112,7 @@ function generate_event( $post ) {
 				$exdate = strtotime( $cancelled_date );
 				// Only list cancelled dates that are valid and in the future or recent past
 				if ( $exdate >= strtotime( 'yesterday' ) ) {
-					$cancelled[ $i ] = strftime( '%Y%m%d', $exdate );
+					$cancelled[ $i ] = gmdate( 'Ymd', $exdate );
 				}
 			}
 			$event .= 'EXDATE:' . implode( ',', $cancelled ) . NEWLINE;
@@ -170,7 +170,7 @@ function get_frequency( $recurrence, $date, $occurrences ) {
 function get_frequencies_by_day( $occurrences, $date ) {
 	// Get the first two letters of the day of the start date in uppercase letters
 	$day = strtoupper(
-		substr( strftime( '%a', strtotime( $date ) ), 0, 2 )
+		substr( gmdate( 'D', strtotime( $date ) ), 0, 2 )
 	);
 
 	$by_days = array_reduce(

--- a/includes/wporg-meeting-posttype.php
+++ b/includes/wporg-meeting-posttype.php
@@ -368,7 +368,7 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 				}
 
 				foreach ( $occurrences as $occurrence ) {
-					$meeting->time = strftime( '%H:%M:%S', strtotime( $meeting->time ) );
+					$meeting->time = gmdate( 'H:i:s', strtotime( $meeting->time ) );
 					$out[]         = array(
 						'meeting_id'  => $meeting->ID,
 						'instance_id' => "{$meeting->ID}:{$occurrence}",
@@ -840,10 +840,10 @@ if ( ! class_exists( 'Meeting_Post_Type' ) ) :
 			$out = '';
 			foreach ( array_slice( $query->posts, 0, $limit ) as $post ) {
 				$next_meeting_datestring = $post->next_date;
-				$utc_time                = strftime( '%H:%M:%S', strtotime( $post->time ) );
+				$utc_time                = gmdate( 'H:i:s', strtotime( $post->time ) );
 				$next_meeting_iso        = $next_meeting_datestring . 'T' . $utc_time . '+00:00';
 				$next_meeting_timestamp  = strtotime( $next_meeting_datestring . ' ' . $utc_time );
-				$next_meeting_display    = strftime( '%c %Z', $next_meeting_timestamp );
+				$next_meeting_display    = gmdate( 'c T', $next_meeting_timestamp );
 
 				$slack_channel = null;
 				if ( $post->location && preg_match( '/^#([-\w]+)$/', trim( $post->location ), $match ) ) {

--- a/tests/test-meetingposttype.php
+++ b/tests/test-meetingposttype.php
@@ -33,7 +33,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'team'       => 'Team-A',
-					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'start_date' => gmdate( 'Y-m-d', strtotime( 'tomorrow' ) ),
 					'end_date'   => '',
 					'time'       => '01:00',
 					'recurring'  => '',
@@ -63,7 +63,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'team'       => 'Team-A',
-					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'start_date' => gmdate( 'Y-m-d', strtotime( 'tomorrow' ) ),
 					'end_date'   => '',
 					'time'       => '0100 UTC', // Some production data is formatted like this
 					'recurring'  => '',
@@ -95,7 +95,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'team'       => 'Team-A&B',
-					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'start_date' => gmdate( 'Y-m-d', strtotime( 'tomorrow' ) ),
 					'end_date'   => '',
 					'time'       => '01:00',
 					'recurring'  => '',

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -33,7 +33,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'team'       => 'Team-F',
-					'start_date' => strftime( '%Y-%m-%d', strtotime( 'tomorrow' ) ),
+					'start_date' => gmdate( 'Y-m-d', strtotime( 'tomorrow' ) ),
 					'end_date'   => '',
 					'time'       => '01:00',
 					'recurring'  => '',
@@ -52,7 +52,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'team'       => 'Team-F',
-					'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
+					'start_date' => gmdate( 'Y-m-d', strtotime( 'yesterday' ) ),
 					'end_date'   => '',
 					'time'       => '02:00',
 					'recurring'  => 'weekly',
@@ -65,11 +65,11 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
-		$expected = strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'tomorrow' ) );
+		$expected = gmdate( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="Y-m-dT01:00:00+00:00" title="Y-m-dT01:00:00+00:00">D M j 01:00:00 Y UTC</time>', strtotime( 'tomorrow' ) );
 		$substr = substr( $actual, strpos( $actual, '<strong class="meeting-title">Meeting One</strong>' ), strlen( $expected ) );
 		$this->assertEquals( $substr, $expected );
 
-		$expected = strftime( '<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="%Y-%m-%dT02:00:00+00:00" title="%Y-%m-%dT02:00:00+00:00">%a %b %e 02:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) );
+		$expected = gmdate( '<strong class="meeting-title">Meeting Two</strong><br/><time class="date" date-time="Y-m-dT02:00:00+00:00" title="Y-m-dT02:00:00+00:00">D M j 02:00:00 Y UTC</time>', strtotime( 'yesterday +7 days' ) );
 		$substr = substr( $actual, strpos( $actual, '<strong class="meeting-title">Meeting Two</strong>' ), strlen( $expected ) );
 		$this->assertEquals( $substr, $expected );
 	}
@@ -84,7 +84,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 				'post_status' => 'publish',
 				'meta_input'  => array(
 					'team'       => 'Team-F',
-					'start_date' => strftime( '%Y-%m-%d', strtotime( 'yesterday' ) ),
+					'start_date' => gmdate( 'Y-m-d', strtotime( 'yesterday' ) ),
 					'end_date'   => '',
 					'time'       => '01:00',
 					'recurring'  => 'weekly',
@@ -99,8 +99,8 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 		$response = $this->mpt->cancel_meeting(
 			array(
 				'meeting_id' => $meeting_1,
-				'date'       => strftime(
-					'%Y-%m-%d',
+				'date'       => gmdate(
+					'Y-m-d',
 					strtotime( 'yesterday +7 days' )
 				),
 			)
@@ -110,7 +110,7 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 		$actual = do_shortcode( '[meeting_time team="Team-F" before="" more=0 limit=-1 /]' );
 
 		// The shortcode should show the next meeting is in 7 days
-		$expected = strftime( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="%Y-%m-%dT01:00:00+00:00" title="%Y-%m-%dT01:00:00+00:00">%a %b %e 01:00:00 %Y UTC</time>', strtotime( 'yesterday +7 days' ) );
+		$expected = gmdate( '<strong class="meeting-title">Meeting One</strong><br/><time class="date" date-time="Y-m-dT01:00:00+00:00" title="Y-m-dT01:00:00+00:00">D M j 01:00:00 Y UTC</time>', strtotime( 'yesterday +7 days' ) );
 		$substr = substr( $actual, strpos( $actual, '<strong class="meeting-title">Meeting One</strong>' ), strlen( $expected ) );
 		$this->assertEquals( $substr, $expected );
 
@@ -118,6 +118,6 @@ class MeetingShortcodeTest extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 0, strpos( $actual, '<p class="wporg-meeting-shortcode meeting-cancelled"' ) );
 
 		// It should give the next date
-		$this->assertGreaterThan( 0, strpos( $actual, strftime( 'This event is cancelled. The next meeting is scheduled for %Y-%m-%d.', strtotime( 'yesterday +14 days' ) ) ) );
+		$this->assertGreaterThan( 0, strpos( $actual, gmdate( 'This event is cancelled. The next meeting is scheduled for Y-m-d.', strtotime( 'yesterday +14 days' ) ) ) );
 	}
 }


### PR DESCRIPTION
This PR fixes PHPCS errors by adding a comment to `.phpcs.xml.dist` and replace deprecated `strftime`.

## TODO
Do some more sandbox testings to see if things work correctly on other sites that use this plugin.