### PR TITLE
Style past events differently from upcoming

### DIFF
--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -56,11 +56,7 @@ function CalendarCell({
 						key={event.instance_id}
 						variant="link"
 						onClick={() => void onEventClick(event)}
-						className={
-							'wporg-meeting-calendar__cell-event ' +
-							getTeamClass(event.team) +
-							(isCancelled(event.status) ? ' is-cancelled' : '')
-						}
+						className={`wporg-meeting-calendar__cell-event ${getTeamClass(event.team)} ${isCancelled(event.status) ? 'is-cancelled' : ''} ${isUpcoming(event.datetime) ? 'is-upcoming' : ''}`}
 					>
 						<div className="wporg-meeting-calendar__cell-event-time">
 							{format('g:i a ', event.datetime)}

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -46,7 +46,9 @@ function CalendarCell({
 						dayEvents.length
 					)}
 				</span>
-				<span aria-hidden>{day}</span>
+				<span className="wporg-meeting-calendar__cell-day" aria-hidden>
+					{day}
+				</span>
 			</strong>
 			{dayEvents.slice(0, MAX_EVENTS).map((event) => {
 				return (

--- a/src/frontend/calendar/cell.js
+++ b/src/frontend/calendar/cell.js
@@ -8,7 +8,7 @@ import { format } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import { getTeamClass, isToday, isCancelled } from './utils';
+import { getTeamClass, isToday, isCancelled, isUpcoming } from './utils';
 
 function CalendarCell({
 	blank = false,
@@ -30,9 +30,7 @@ function CalendarCell({
 
 	return (
 		<td
-			className={`wporg-meeting-calendar__cell ${
-				isToday(date) ? 'is-today' : ''
-			}`}
+			className={`wporg-meeting-calendar__cell ${isToday(date) ? 'is-today' : ''} ${isUpcoming(date) ? 'is-upcoming' : ''}`}
 		>
 			<strong>
 				<span className="screen-reader-text">
@@ -54,7 +52,7 @@ function CalendarCell({
 				return (
 					<Button
 						key={event.instance_id}
-						isLink
+						variant="link"
 						onClick={() => void onEventClick(event)}
 						className={
 							'wporg-meeting-calendar__cell-event ' +

--- a/src/frontend/calendar/utils.js
+++ b/src/frontend/calendar/utils.js
@@ -15,34 +15,34 @@ const emptyDate = {
  * @param {number} year
  * @param {number} month
  */
-export function getRows( year, month ) {
+export function getRows(year, month) {
 	const daysInWeek = 7;
-	const firstOffset = new Date( year, month, 1 ).getDay(); // Get day of the week.
-	const monthLength = new Date( year, month + 1, 0 ).getDate(); // 0 gets the last day of the next month.
+	const firstOffset = new Date(year, month, 1).getDay(); // Get day of the week.
+	const monthLength = new Date(year, month + 1, 0).getDate(); // 0 gets the last day of the next month.
 	const days = [];
 
-	for ( let i = 0; i < firstOffset; i++ ) {
-		days.push( emptyDate );
+	for (let i = 0; i < firstOffset; i++) {
+		days.push(emptyDate);
 	}
-	for ( let i = 1; i <= monthLength; i++ ) {
-		days.push( {
+	for (let i = 1; i <= monthLength; i++) {
+		days.push({
 			month,
 			year,
 			day: i,
-		} );
+		});
 	}
 
 	const rows = [];
-	for ( let i = 0; i < Math.ceil( days.length / daysInWeek ); i++ ) {
+	for (let i = 0; i < Math.ceil(days.length / daysInWeek); i++) {
 		const start = i * daysInWeek;
-		let row = days.slice( start, start + daysInWeek );
-		if ( row.length !== daysInWeek ) {
+		let row = days.slice(start, start + daysInWeek);
+		if (row.length !== daysInWeek) {
 			row = [
 				...row,
 				...Array( daysInWeek - row.length ).fill( emptyDate ),
 			];
 		}
-		rows.push( row );
+		rows.push(row);
 	}
 
 	return rows;
@@ -53,32 +53,32 @@ export function getRows( year, month ) {
  *
  * @param {Object} event
  */
-export function getFrequencyLabel( event ) {
+export function getFrequencyLabel(event) {
 	const occurrences = {
-		1: __( '1st', 'wporg-meeting-calendar' ),
-		2: __( '2nd', 'wporg-meeting-calendar' ),
-		3: __( '3rd', 'wporg-meeting-calendar' ),
-		4: __( '4th', 'wporg-meeting-calendar' ),
+		1: __('1st', 'wporg-meeting-calendar'),
+		2: __('2nd', 'wporg-meeting-calendar'),
+		3: __('3rd', 'wporg-meeting-calendar'),
+		4: __('4th', 'wporg-meeting-calendar'),
 	};
-	const dayOfWeek = format( 'l', event.datetime );
+	const dayOfWeek = format('l', event.datetime);
 
-	switch ( event.recurring ) {
+	switch (event.recurring) {
 		case 'weekly':
 			return sprintf( __( 'Every week on %s', 'wporg-meeting-calendar' ), dayOfWeek );
 
 		case 'biweekly':
 			return sprintf(
-				__( 'Every other week on %s', 'wporg-meeting-calendar' ),
+				__('Every other week on %s', 'wporg-meeting-calendar'),
 				dayOfWeek
 			);
 
 		case 'monthly':
-			return __( 'Every month', 'wporg-meeting-calendar' );
+			return __('Every month', 'wporg-meeting-calendar');
 
 		case 'occurrence':
-			if ( event.occurrence.length ) {
+			if (event.occurrence.length) {
 				return sprintf(
-					__( 'Every month on the %s %s', 'wporg-meeting-calendar' ),
+					__('Every month on the %s %s', 'wporg-meeting-calendar'),
 					event.occurrence
 						.map( ( o ) => occurrences[ o ] )
 						.join( ', ' ),
@@ -88,7 +88,7 @@ export function getFrequencyLabel( event ) {
 			return '';
 
 		default:
-			return __( 'Does not repeat', 'wporg-meeting-calendar' );
+			return __('Does not repeat', 'wporg-meeting-calendar');
 	}
 }
 
@@ -97,16 +97,16 @@ export function getFrequencyLabel( event ) {
  *
  * @param {string} location
  */
-export function getSlackLink( location ) {
-	if ( location[ 0 ] === '#' ) {
-		location = location.slice( 1 );
+export function getSlackLink(location) {
+	if (location[0] === '#') {
+		location = location.slice(1);
 	}
 
 	return (
 		<a
-			href={ `https://wordpress.slack.com/app_redirect?channel=${ location }` }
+			href={`https://wordpress.slack.com/app_redirect?channel=${location}`}
 		>
-			#{ location }
+			#{location}
 		</a>
 	);
 }
@@ -116,10 +116,10 @@ export function getSlackLink( location ) {
  *
  * @param {string} team
  */
-export function getTeamClass( team ) {
+export function getTeamClass(team) {
 	return (
 		'wporg-meeting-calendar__team-' +
-		team.replace( [ ' ', '.' ], '-' ).toLowerCase()
+		team.replace([' ', '.'], '-').toLowerCase()
 	);
 }
 
@@ -128,7 +128,7 @@ export function getTeamClass( team ) {
  *
  * @param {Object} date
  */
-export function isToday( date ) {
+export function isToday(date) {
 	const today = new Date();
 	return (
 		date.getDate() == today.getDate() &&
@@ -142,6 +142,15 @@ export function isToday( date ) {
  *
  * @param {string} status Status of the event Ie: active, cancelled
  */
-export function isCancelled( status ) {
+export function isCancelled(status) {
 	return 'cancelled' === status;
+}
+
+/**
+ * Checks whether a date is upcoming
+ *
+ * @param {string} eventDatetime The date and time of the event in UTC
+ */
+export function isUpcoming(eventDatetime) {
+	return new Date(eventDatetime) > new Date();
 }

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -364,6 +364,12 @@
 	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
 }
 
+.wporg-meeting-calendar__cell-day {
+	display: inline-block;
+	width: 30px;
+	height: 100%;
+}
+
 .wporg-meeting-calendar__cell {
 	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
 	background-color: var(--wp--preset--color--light-grey-2, #f6f6f6);
@@ -373,26 +379,27 @@
 
 	strong {
 		display: block;
+		height: 30px;
+		line-height: 30px;
 		text-align: center;
 		font-weight: 400;
 		font-size: var(--wp--preset--font-size--normal, 16px);
 		color: var(--wp--preset--color--charcoal-4, #656a71);
 	}
 
+	&.is-today,
 	&.is-upcoming {
 		background-color: var(--wp--preset--color--white, #fff);
 	}
 
-	&.is-today {
-		background-color: var(--wp--preset--color--acid-green-3, #e2ffed);
+	&.is-today .wporg-meeting-calendar__cell-day {
+		background-color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+		border-radius: 50%;
+		color: var(--wp--preset--color--white, #fff);
 	}
 
-	&.is-upcoming,
-	&.is-today {
-
-		strong {
-			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
-		}
+	&.is-upcoming strong {
+		color: var(--wp--preset--color--charcoal-1, #1e1e1e);
 	}
 }
 

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -366,6 +366,7 @@
 
 .wporg-meeting-calendar__cell {
 	border: 1px solid var(--wp--preset--color--light-grey-1, #d9d9d9);
+	background-color: var(--wp--preset--color--light-grey-2, #f6f6f6);
 	padding: var(--wp--preset--spacing--10, 10px);
 	vertical-align: top;
 	height: 180px; /* height acts as min-height on table cells */
@@ -374,16 +375,24 @@
 		display: block;
 		text-align: center;
 		font-weight: 400;
-		font-size: var(--wp--preset--font-size--normal);
+		font-size: var(--wp--preset--font-size--normal, 16px);
+		color: var(--wp--preset--color--charcoal-4, #656a71);
 	}
 
-	&:first-child,
-	&:last-child {
-		background-color: var(--wp--preset--color--light-grey-2, #f6f6f6);
+	&.is-upcoming {
+		background-color: var(--wp--preset--color--white, #fff);
 	}
 
 	&.is-today {
 		background-color: var(--wp--preset--color--acid-green-3, #e2ffed);
+	}
+
+	&.is-upcoming,
+	&.is-today {
+
+		strong {
+			color: var(--wp--preset--color--charcoal-1, #1e1e1e);
+		}
 	}
 }
 

--- a/src/frontend/style.scss
+++ b/src/frontend/style.scss
@@ -424,7 +424,7 @@
 
 .wporg-meeting-calendar__team-polyglots {
 	border-color: #c32283 !important;
-	background-color: color.adjust(#c32283, $lightness: 45%) !important;
+	background-color: color.adjust(#c32283, $lightness: 50%) !important;
 	color: color.adjust(#c32283, $lightness: -10%) !important;
 }
 
@@ -515,6 +515,11 @@
 	border-color: #d84800 !important;
 	background-color: color.adjust(#d84800, $lightness: 50%) !important;
 	color: color.adjust(#d84800, $lightness: -10%) !important;
+}
+
+.wporg-meeting-calendar__cell-event:not(.is-upcoming) {
+	opacity: 0.58;
+	color: #000 !important;
 }
 
 .wporg-meeting-calendar__modal {


### PR DESCRIPTION
Alternative to https://github.com/WordPress/meeting-calendar/pull/157

Uses a background color on the calendar cells [as suggested](https://meta.trac.wordpress.org/ticket/6868#comment:5), so that we maintain contrast ratios on events for accessibility. Also slightly dims the color of the day number on past days.

Props joen, marcochiesi

cc @WordPress/meta-design 

Closes https://meta.trac.wordpress.org/ticket/6868

| Before | After |
|--------|--------|
| ![make wordpress org_meetings__new-theme=1 (3)](https://github.com/user-attachments/assets/86e40a05-8e8b-450f-8e40-97019ef9f59c) | ![make wordpress org_meetings__new-theme=1 (2)](https://github.com/user-attachments/assets/bc0b24f7-e4bb-4e33-a202-9da70f7fa3dc) | 