### PR TITLE
Update references from Automattic to WordPress.org.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"homepage": "https://make.wordpress.org/meetings",
 	"license": "GPL-2.0-or-later",
 	"support": {
-		"issues": "https://github.com/Automattic/meeting-calendar/issues"
+		"issues": "https://github.com/WordPress/meeting-calendar/issues"
 	},
 	"config": {
 		"platform": {

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Automattic/meeting-calendar.git"
+    "url": "git+https://github.com/WordPress/meeting-calendar.git"
   },
   "author": "",
   "license": "GPL-2.0-or-later",
   "bugs": {
-    "url": "https://github.com/Automattic/meeting-calendar/issues"
+    "url": "https://github.com/WordPress/meeting-calendar/issues"
   },
-  "homepage": "https://github.com/Automattic/meeting-calendar#readme",
+  "homepage": "https://github.com/WordPress/meeting-calendar#readme",
   "devDependencies": {
     "@wordpress/env": "10.13.0",
     "@wordpress/scripts": "30.6.0",

--- a/plugin.php
+++ b/plugin.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: Meeting Calendar
  * Description: This provides a way of scheduling recurring meetings, and displaying a calendar or timetable..
- * Plugin URI: https://github.com/Automattic/meeting-calendar
- * Author: Automattic
+ * Plugin URI: https://github.com/WordPress/meeting-calendar
+ * Author: WordPress.org Contributors
  * Version: 1.1.0
  * Text Domain: wporg-meeting-calendar
  * License: GPL2+

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Meeting Calendar ===
 Contributors: tellyworth,dufresnesteven,dd32,ryelle
-Author URI: https://automattic.com/
+Author URI: https://make.wordpress.org/meta/
 Tags: meeting,calendar
 Requires at least: 4.5
 Tested up to: 5.2.1

--- a/tests/test-meetingposttype.php
+++ b/tests/test-meetingposttype.php
@@ -24,7 +24,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 	}
 
 	function test_single_meeting() {
-		// See https://github.com/Automattic/meeting-calendar/issues/34
+		// See https://github.com/WordPress/meeting-calendar/issues/34
 
 		$meeting_id = $this->factory->post->create(
 			array(
@@ -124,7 +124,7 @@ class MeetingPostTypeTest extends WP_UnitTestCase {
 
 	/*
 	 * There was a bug with the meeting_set_next_meeting() filter, where it was interfering with the sorting of other post types.
-	 * See https://github.com/Automattic/meeting-calendar/issues/98
+	 * See https://github.com/WordPress/meeting-calendar/issues/98
 	 */
 	function test_sort_filter_bug() {
 		$category = $this->factory->category->create( array(


### PR DESCRIPTION
Fixes #117 