### PR TITLE
Fix loading teams with a space in the name.

### DIFF
--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -15,7 +15,7 @@ import { getSortedEvents } from './utils';
 function getTeamOnLoad() {
 	const { location } = window;
 	const matches = location.href.match( /#(.+)/ );
-	return matches ? matches[ 1 ] : '';
+	return matches ? decodeURI( matches[ 1 ] ) : '';
 }
 
 /**

--- a/src/frontend/store/event-context.js
+++ b/src/frontend/store/event-context.js
@@ -42,12 +42,6 @@ export function EventsProvider( { children, value } ) {
 
 	let eventsToDisplay = value;
 
-	if ( team && team.trim().length ) {
-		eventsToDisplay = value.filter(
-			( e ) => e.team.toLowerCase() === team.toLowerCase()
-		);
-	}
-
 	// Get a list of all teams available.
 	const teams = uniqBy(
 		value
@@ -58,6 +52,24 @@ export function EventsProvider( { children, value } ) {
 			.filter( ( { value } ) => !! value ),
 		'value'
 	);
+
+	// Validate the team is valid.
+	if ( team && team.trim().length ) {
+		const teamExists = teams.find(
+			( t ) => t.value.toLowerCase() === team.toLowerCase()
+		);
+		if ( ! teamExists ) {
+			team = '';
+			setTeam( '' );
+		}
+	}
+
+	// Filter the initial events list.
+	if ( team && team.trim().length ) {
+		eventsToDisplay = value.filter(
+			( e ) => e.team.toLowerCase() === team.toLowerCase()
+		);
+	}
 
 	const initialState = {
 		events: getSortedEvents( eventsToDisplay ),


### PR DESCRIPTION
As noted in #169 when you load a team such as this: https://make.wordpress.org/meetings/#core%20performance you end up with a Javascript error.

Additionally; If you attempt to load a team which does not exist (ie. https://make.wordpress.org/meetings/#not+a+team ), you also end up with a similar error.

